### PR TITLE
Updated plugin update and install to handle plugin versioning

### DIFF
--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -75,8 +75,8 @@ func NewForSource(source, version string) (Installer, error) {
 }
 
 // FindSource determines the correct Installer for the given source.
-func FindSource(location string) (Installer, error) {
-	installer, err := existingVCSRepo(location)
+func FindSource(location, version string) (Installer, error) {
+	installer, err := existingVCSRepo(location, version)
 	if err != nil && err.Error() == "Cannot detect VCS" {
 		return installer, errors.New("cannot get information about plugin source")
 	}

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -16,11 +16,11 @@ limitations under the License.
 package installer // import "helm.sh/helm/v3/pkg/plugin/installer"
 
 import (
+	"github.com/Masterminds/vcs"
 	"os"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/Masterminds/vcs"
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/internal/third_party/dep/fs"
@@ -35,14 +35,15 @@ type VCSInstaller struct {
 	base
 }
 
-func existingVCSRepo(location string) (Installer, error) {
+func existingVCSRepo(location, version string) (Installer, error) {
 	repo, err := vcs.NewRepo("", location)
 	if err != nil {
 		return nil, err
 	}
 	i := &VCSInstaller{
-		Repo: repo,
-		base: newBase(repo.Remote()),
+		Repo:    repo,
+		Version: version,
+		base:    newBase(repo.Remote()),
 	}
 	return i, nil
 }
@@ -82,6 +83,8 @@ func (i *VCSInstaller) Install() error {
 		if err := i.setVersion(i.Repo, ref); err != nil {
 			return err
 		}
+	} else if err := updateToLatest(i.Repo); err != nil {
+		return err
 	}
 
 	if !isPlugin(i.Repo.LocalPath()) {
@@ -98,7 +101,15 @@ func (i *VCSInstaller) Update() error {
 	if i.Repo.IsDirty() {
 		return errors.New("plugin repo was modified")
 	}
-	if err := i.Repo.Update(); err != nil {
+	ref, err := i.solveVersion(i.Repo)
+	if err != nil {
+		return err
+	}
+	if ref != "" {
+		if err := i.setVersion(i.Repo, ref); err != nil {
+			debug(err.Error())
+		}
+	} else if err := updateToLatest(i.Repo); err != nil {
 		return err
 	}
 	if !isPlugin(i.Repo.LocalPath()) {
@@ -139,7 +150,6 @@ func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
 		if constraint.Check(v) {
 			// If the constraint passes get the original reference
 			ver := v.Original()
-			debug("setting to %s", ver)
 			return ver, nil
 		}
 	}
@@ -173,4 +183,20 @@ func getSemVers(refs []string) []*semver.Version {
 		}
 	}
 	return sv
+}
+
+func updateToLatest(repo vcs.Repo) error {
+	refs, err := repo.Tags()
+	if err != nil {
+		return err
+	}
+	debug("found refs: %s", refs)
+
+	// Convert and filter the list to semver.Version instances
+	semvers := getSemVers(refs)
+
+	// Sort semver list
+	sort.Sort(sort.Reverse(semver.Collection(semvers)))
+	latest := semvers[0].Original()
+	return repo.UpdateVersion(latest)
 }


### PR DESCRIPTION
Signed-off-by: Mihael Rodek <mihael.rodek1@gmail.com>

closes #10929

**What this PR does / why we need it**: Fixes the plugin update and plugin install commands using better version handling
e.g.
 ```helm plugin install [options] <path|url>...``` now installs the latest version and not one fetched from cache
 ```helm plugin update <plugin:[version]>...`` now allows user to specify to which version should plugin be updated to
**Special notes for your reviewer**: Plugin now prioritizes latest version over the cached

